### PR TITLE
Improve version handling and diagnostics

### DIFF
--- a/build/finishautobuildweb.sh
+++ b/build/finishautobuildweb.sh
@@ -13,7 +13,10 @@ rm -rf $publish/runtimes/{osx,win}
 > $publish/runtimes/linux/native/libgrpc_csharp_ext.x86.so
 
 # Add diagnostic text files
-echo $combined_commit > $publish/wwwroot/commit.txt
+echo "Combined: $combined_commit" > $publish/wwwroot/commit.txt
+echo "nodatime: $nodatime_commit" >> $publish/wwwroot/commit.txt
+echo "nodatime.org: $nodatime_org_commit" >> $publish/wwwroot/commit.txt
+echo "nodatime.serialization: $nodatime_serialization_commit" >> $publish/wwwroot/commit.txt
 echo "Built at $(date -u -Iseconds)" > $publish/wwwroot/build.txt 
 
 echo "Build and test successful. Pushing."


### PR DESCRIPTION
- Redirect versions more liberally, so we don't need to check expected versions
- Use the release repository to work out the redirects for /api and /userguide
- Don't tell browsers to cache commit.txt or build.txt
- Put more information in commit.txt