### PR TITLE
Simple xref generator for packages using Sandcastle

### DIFF
--- a/build/SandcastleXrefGenerator/Program.cs
+++ b/build/SandcastleXrefGenerator/Program.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using Microsoft.DocAsCode.Build.Engine;
+using Microsoft.DocAsCode.Plugins;
+using Mono.Cecil;
+using SharpCompress.Archives.Zip;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+
+namespace SandcastleXrefGenerator
+{
+    class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            if (args.Length != 4)
+            {
+                Console.WriteLine("Usage: <nuget package> <version> <tfm> <baseUrl>");
+                return 1;
+            }
+
+            Stream packageStream = await DownloadPackage(args[0], args[1]);
+            var module = LoadModule(packageStream, args[2]);
+
+            var map = BuildXRefMap(module, args[3]);
+            var serializer = new SerializerBuilder().Build();
+            var yaml = serializer.Serialize(map);
+            Console.WriteLine(yaml);
+            return 0;
+        }
+
+        static async Task<Stream> DownloadPackage(string package, string version)
+        {
+            var client = new HttpClient();
+            byte[] bytes = await client.GetByteArrayAsync($"https://www.nuget.org/api/v2/package/{package}/{version}");
+            return new MemoryStream(bytes);
+        }
+
+        static ModuleDefinition LoadModule(Stream package, string tfm)
+        {
+            string prefix = $"lib/{tfm}";
+            using (var zip = ZipArchive.Open(package))
+            {
+                foreach (var entry in zip.Entries)
+                {
+                    // We assume there's just one assembly, for simplicity.
+                    if (entry.Key.StartsWith(prefix) && entry.Key.EndsWith(".dll"))
+                    {
+                        using (var stream = entry.OpenEntryStream())
+                        {
+                            // Mono.Cecil requires the stream to be seekable. It's simplest
+                            // just to copy the whole DLL to a MemoryStream and pass that to Cecil.
+                            var ms = new MemoryStream();
+                            stream.CopyTo(ms);
+                            ms.Position = 0;
+                            return ModuleDefinition.ReadModule(ms);
+                        }
+                    }
+                }
+            }
+            throw new Exception($"No file found in package starting with '{prefix}'");
+        }
+
+        static XRefMap BuildXRefMap(ModuleDefinition module, string baseUrl)
+        {
+            var map = new XRefMap
+            {
+                BaseUrl = baseUrl,
+                References = module.Types
+                    .Select(CreateXRefSpec)
+                    .Where(spec => spec != null)
+                    .ToList()
+            };
+            return map;
+        }
+
+        static XRefSpec CreateXRefSpec(TypeDefinition type)
+        {
+            if (!type.IsPublic)
+            {
+                return null;
+            }
+            return new XRefSpec
+            {
+                Name = type.Name, // TODO: Get the name with <T> etc in
+                Uid = type.FullName, // Is this really enough?
+                Href = $"T_{type.FullName.Replace('.', '_').Replace('`', '_')}.htm",
+                CommentId = $"T:{type.FullName}"
+            };
+        }
+    }
+}

--- a/build/SandcastleXrefGenerator/SandcastleXrefGenerator.csproj
+++ b/build/SandcastleXrefGenerator/SandcastleXrefGenerator.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- It's this dependency that forces us to use the full framework. Replace when we can... -->
+    <PackageReference Include="Microsoft.DocAsCode.Build.Engine" Version="2.41.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />
+    <PackageReference Include="MoreLinq" Version="2.3.0" />
+    <PackageReference Include="SharpCompress" Version="0.15.2" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/build/Tools.sln
+++ b/build/Tools.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnippetExtractor", "Snippet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocfxNullableReferenceFixer", "DocfxNullableReferenceFixer\DocfxNullableReferenceFixer.csproj", "{1ACA69E6-23B5-4AD3-AFE9-5400E13BB7C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SandcastleXrefGenerator", "SandcastleXrefGenerator\SandcastleXrefGenerator.csproj", "{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,16 @@ Global
 		{1ACA69E6-23B5-4AD3-AFE9-5400E13BB7C1}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
 		{1ACA69E6-23B5-4AD3-AFE9-5400E13BB7C1}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{1ACA69E6-23B5-4AD3-AFE9-5400E13BB7C1}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
+		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/buildapidocs.sh
+++ b/build/buildapidocs.sh
@@ -83,6 +83,9 @@ cp docfx/serialization-toc.yml tmp/web/serialization/toc.yml
 mkdir -p tmp/web/commonoverwrite
 cp docfx/namespaces.md tmp/web/commonoverwrite
 
+# Copy local xref maps
+cp -r history/xrefs tmp
+
 cp docfx/docfx-web.json tmp
 cp -r docfx/template tmp
 echo "Running main docfx build"

--- a/build/buildhistory.sh
+++ b/build/buildhistory.sh
@@ -148,6 +148,13 @@ fetch_packages NodaTime.Testing 1.0 1.1 1.2 1.3 1.4 2.0 2.1 2.2 2.3 2.4
 fetch_packages NodaTime.Serialization.JsonNet 1.2 1.3 1.4 2.0 2.1 2.2
 fetch_packages NodaTime.Serialization.Protobuf 1.0
 
+echo "Generating xref maps"
+mkdir xrefs
+dotnet run -p ../SandcastleXrefGenerator -- \
+    Newtonsoft.Json 12.0.1 netstandard2.0 \
+    https://www.newtonsoft.com/json/help/html/ \
+    > xrefs/Newtonsoft.Json-xrefmap.yml
+
 # Clean up
 rm -rf main
 rm -rf serialization
@@ -170,6 +177,7 @@ End-of-travis
 git checkout HEAD -- NodaTime/2.1.x/overwrite/snippets.md
 git checkout HEAD -- NodaTime/2.2.x/overwrite/snippets.md
 git checkout HEAD -- NodaTime/2.3.x/overwrite/snippets.md
+
 
 git add --all
 git commit -q -m "Regenerated history directory"

--- a/build/docfx/docfx-web.json
+++ b/build/docfx/docfx-web.json
@@ -18,7 +18,8 @@
     // It's not ideal that these are specified in the root, but it appears to work.
     // See https://github.com/dotnet/docfx/issues/4346
     "xref": [
-     "https://nodatime.org/2.4.x.xrefmap.yml"
+      "https://nodatime.org/2.4.x.xrefmap.yml",
+      "xrefs/Newtonsoft.Json-xrefmap.yml"
     ],
     // Add an xrefService for BCL types
     "xrefService": [


### PR DESCRIPTION
Also modify the build scripts to use the generated map for Newtonsoft.Json

Fixes #13

Note that this *only* generates the map for types; that's all we need.