### PR TITLE
More robust handling for benchmarks

### DIFF
--- a/src/NodaTime.Web/Controllers/BenchmarksController.cs
+++ b/src/NodaTime.Web/Controllers/BenchmarksController.cs
@@ -24,10 +24,10 @@ namespace NodaTime.Web.Controllers
         public IActionResult Index() => View(repository.ListEnvironments());
 
         [Route("/benchmarks/environments/{id}")]
-        public IActionResult ViewEnvironment(string id) => View(repository.GetEnvironment(id));
+        public IActionResult ViewEnvironment(string id) => ViewOrNotFound(repository.GetEnvironment(id));
 
         [Route("/benchmarks/runs/{runId}")]
-        public IActionResult ViewRun(string runId) => View(repository.GetRun(runId));
+        public IActionResult ViewRun(string runId) => ViewOrNotFound(repository.GetRun(runId));
 
         [Route("/benchmarks/types/{typeId}")]
         public IActionResult ViewType(string typeId)
@@ -48,6 +48,10 @@ namespace NodaTime.Web.Controllers
         public IActionResult CompareTypesByEnvironment(string typeId)
         {
             var left = repository.GetType(typeId);
+            if (left == null)
+            {
+                return NotFound();
+            }
             var runs = repository.ListEnvironments()
                 .Select(e => e.Runs.FirstOrDefault(r => r.Commit == left.Run.Commit))
                 .Where(r => r != null && r != left.Run)
@@ -78,7 +82,7 @@ namespace NodaTime.Web.Controllers
         }
 
         [Route("/benchmarks/benchmarks/{benchmarkId}")]
-        public IActionResult ViewBenchmark(string benchmarkId) => View(repository.GetBenchmark(benchmarkId));
+        public IActionResult ViewBenchmark(string benchmarkId) => ViewOrNotFound(repository.GetBenchmark(benchmarkId));
 
         [Route("/benchmarks/benchmarks/{benchmarkId}/history")]
         public IActionResult ViewBenchmarkHistory(string benchmarkId)
@@ -102,6 +106,9 @@ namespace NodaTime.Web.Controllers
             repository.GetEnvironment(run.BenchmarkEnvironmentId)?.Runs
                 .SkipWhile(r => r.BenchmarkRunId != run.BenchmarkRunId)
                 .Skip(1)
-                .FirstOrDefault();            
+                .FirstOrDefault();
+
+        private IActionResult ViewOrNotFound(object? model) =>
+            model == null ? (IActionResult) NotFound() : View(model);
     }
 }

--- a/src/NodaTime.Web/Helpers/DictionaryExtensions.cs
+++ b/src/NodaTime.Web/Helpers/DictionaryExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2019 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NodaTime.Web.Helpers
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue? GetValueOrNull<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+            where TValue : class =>
+            dictionary.TryGetValue(key, out var value) ? value : null;
+    }
+}

--- a/src/NodaTime.Web/Services/BenchmarkRepository.cs
+++ b/src/NodaTime.Web/Services/BenchmarkRepository.cs
@@ -34,13 +34,12 @@ namespace NodaTime.Web.Services
             cache.Start();
         }
         
-        public IList<BenchmarkEnvironment>? ListEnvironments() => cache.Value.Environments;
-        // TODO: Don't throw if asked for an invalid value...
-        public BenchmarkEnvironment? GetEnvironment(string environmentId) => cache.Value.EnvironmentsById[environmentId];
-        public BenchmarkType? GetType(string benchmarkTypeId) => cache.Value.TypesById[benchmarkTypeId];
-        public BenchmarkRun? GetRun(string benchmarkRunId) => cache.Value.RunsById[benchmarkRunId];
-        public Benchmark? GetBenchmark(string benchmarkId) => cache.Value.BenchmarksById[benchmarkId];
-        public IList<BenchmarkType>? GetTypesByCommitAndType(string commit, string fullTypeName) =>
+        public IList<BenchmarkEnvironment> ListEnvironments() => cache.Value.Environments;
+        public BenchmarkEnvironment? GetEnvironment(string environmentId) => cache.Value.EnvironmentsById.GetValueOrNull(environmentId);
+        public BenchmarkType? GetType(string benchmarkTypeId) => cache.Value.TypesById.GetValueOrNull(benchmarkTypeId);
+        public BenchmarkRun? GetRun(string benchmarkRunId) => cache.Value.RunsById.GetValueOrNull(benchmarkRunId);
+        public Benchmark? GetBenchmark(string benchmarkId) => cache.Value.BenchmarksById.GetValueOrNull(benchmarkId);
+        public IList<BenchmarkType> GetTypesByCommitAndType(string commit, string fullTypeName) =>
             cache.Value.TypesByCommitAndFullName[(commit, fullTypeName)].ToList();
 
         private class CacheValue

--- a/src/NodaTime.Web/Services/IBenchmarkRepository.cs
+++ b/src/NodaTime.Web/Services/IBenchmarkRepository.cs
@@ -12,7 +12,7 @@ namespace NodaTime.Web.Services
         BenchmarkType? GetType(string benchmarkTypeId);
         BenchmarkRun? GetRun(string benchmarkRunId);
         Benchmark? GetBenchmark(string benchmarkId);
-        IList<BenchmarkEnvironment>? ListEnvironments();
-        IList<BenchmarkType>? GetTypesByCommitAndType(string commit, string fullTypeName);
+        IList<BenchmarkEnvironment> ListEnvironments();
+        IList<BenchmarkType> GetTypesByCommitAndType(string commit, string fullTypeName);
     }
 }


### PR DESCRIPTION
Don't throw an exception if an unknown GUID is given - just return a 404