### PR TITLE
Fix NRE in benchmarks

### DIFF
--- a/src/NodaTime.Web/Controllers/BenchmarksController.cs
+++ b/src/NodaTime.Web/Controllers/BenchmarksController.cs
@@ -56,6 +56,7 @@ namespace NodaTime.Web.Controllers
                 .Select(e => e.Runs.FirstOrDefault(r => r.Commit == left.Run.Commit))
                 .Where(r => r != null && r != left.Run)
                 .Select(r => r.Types_.FirstOrDefault(t => t.FullTypeName == left.FullTypeName))
+                .Where(t => t != null)
                 .ToList();
             // Always make the selected run the first one.
             runs.Insert(0, left);


### PR DESCRIPTION
(As found by GCP error reporting.)

We fail with an NRE if we're asked to compare benchmarks for a type
across different environments, in a commit where some environments
have tests for that type and some don't. Notably, BclDateTimeZone
used to have tests in Windows but not Linux.