### PR TITLE
Typo fix

### DIFF
--- a/src/NodaTime.Web/Markdown/2.0.x/range.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/range.md
@@ -88,7 +88,7 @@ Instant
 ----
 
 The range for [`Instant`](noda-type://NodaTime.Instant) is simply the range of the Gregorian calendar, in UTC.
-In other words, it covers -9998-01-01T00:00:00Z to 9999-12-031T23:59:59.999999999Z inclusive.
+In other words, it covers -9998-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z inclusive.
 
 LocalDateTime, LocalDate, ZonedDateTime, and OffsetDateTime
 ----


### PR DESCRIPTION
Came across this while perusing https://nodatime.org/3.0.x/userguide/range today. I looked under the `3.0.x` directory, but it appears this page is only under the `2.0.x` directory, so editing here on the assumption that the build/host process layers them.