### PR TITLE
Link YearMonth patterns to correct API doco page

### DIFF
--- a/src/NodaTime.Web/Markdown/3.0.x/yearmonth-patterns.md
+++ b/src/NodaTime.Web/Markdown/3.0.x/yearmonth-patterns.md
@@ -1,6 +1,6 @@
 @Title="Patterns for YearMonth values"
 
-The [`YearMonth`](noda-type://NodaTime.LocalDate) type supports the following patterns:
+The [`YearMonth`](noda-type://NodaTime.YearMonth) type supports the following patterns:
 
 Standard Patterns
 -----------------


### PR DESCRIPTION
The `YearMonth` patterns page is currently linking to the API documentation for `LocalDate` at the very top. This corrects that link.