### PR TITLE
Fix grammatical error in core-types.md

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/core-types.md
@@ -3,7 +3,7 @@
 This is a companion page to the
 ["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
-If you're not familiar with the core concepts, read those pages first.
+If you're not familiar with the core concepts, read the core concepts page first.
 
 Instant
 -------

--- a/src/NodaTime.Web/Markdown/1.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/core-types.md
@@ -3,7 +3,7 @@
 This is a companion page to the
 ["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
-If you're not familiar with the core concepts, read that page first.
+If you're not familiar with the core concepts, read those pages first.
 
 Instant
 -------

--- a/src/NodaTime.Web/Markdown/2.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/core-types.md
@@ -3,7 +3,7 @@
 This is a companion page to the
 ["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
-If you're not familiar with the core concepts, read those pages first.
+If you're not familiar with the core concepts, read the core concepts page first.
 
 Instant
 -------

--- a/src/NodaTime.Web/Markdown/2.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/core-types.md
@@ -3,7 +3,7 @@
 This is a companion page to the
 ["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
-If you're not familiar with the core concepts, read that page first.
+If you're not familiar with the core concepts, read those pages first.
 
 Instant
 -------


### PR DESCRIPTION
I think this change is what was intended. It's possible that only one of the two pages mentioned was meant to be referenced, in which case it's probably better to name it explicitly.