### PR TITLE
Log all environment variables before building

### DIFF
--- a/build/finishautobuildweb.sh
+++ b/build/finishautobuildweb.sh
@@ -2,6 +2,10 @@
 # It allows the second phase of the script to be updated without
 # refetching the file for the first phase.
 
+echo "Environment:"
+env
+echo ""
+
 # Build site and run smoke tests
 (cd $output/nodatime.org/build; ./buildweb.sh)
 


### PR DESCRIPTION
This should help with the immediate problem of diagnosing why the
snippets aren't building, but will be useful long-term too.