### PR TITLE
Fixes for docfx

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.66.2",
+      "version": "2.63.0",
       "commands": [
         "docfx"
       ]

--- a/build/DocfxAnnotationGenerator/DocfxAnnotationGenerator.csproj
+++ b/build/DocfxAnnotationGenerator/DocfxAnnotationGenerator.csproj
@@ -2,14 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />
-    <PackageReference Include="MoreLinq" Version="2.3.0" />
-    <PackageReference Include="SharpCompress" Version="0.29.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="SharpCompress" Version="0.33.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/DocfxAnnotationGenerator/Program.cs
+++ b/build/DocfxAnnotationGenerator/Program.cs
@@ -1,5 +1,4 @@
 ﻿using DocfxYamlLoader;
-using MoreLinq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -72,10 +71,13 @@ namespace DocfxAnnotationGenerator
                 .SelectMany(rd => rd.Members)
                 .Select(member => member.DocfxUid)
                 .Where(uid => !unstableRelease.MembersByUid.ContainsKey(uid))
-                // IXmlSerializable.GetSchema seems to cause problems for some reason.
+                // Explicit interface implementation seems to cause problems for some reason.
                 // Not sure why, but let's ignore it for now... it really doesn't matter that
                 // it won't have any documentation.
-                .Where(uid => !uid.EndsWith(".System#Xml#Serialization#IXmlSerializable#GetSchema"))
+                .Where(uid => !uid.Contains(".System#Xml#Serialization#IXmlSerializable#") &&
+                              !uid.Contains(".System#IComparable#CompareTo") &&
+                              !uid.Contains(".NodaTime#TimeZones#IDateTimeZoneSource#ForId") &&
+                              !uid.Contains("#GetEnumerator"))
                 .Distinct()
                 .ToList();
             if (missing.Count != 0)

--- a/build/DocfxYamlLoader/DocfxYamlLoader.csproj
+++ b/build/DocfxYamlLoader/DocfxYamlLoader.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="5.4.0" />
+    <PackageReference Include="YamlDotNet" Version="13.1.0" />
   </ItemGroup>
 
 </Project>

--- a/build/DocfxYamlLoader/Release.cs
+++ b/build/DocfxYamlLoader/Release.cs
@@ -9,7 +9,7 @@ namespace DocfxYamlLoader
     public class Release
     {
         private static readonly IDeserializer deserializer = new DeserializerBuilder()
-            .WithNamingConvention(new CamelCaseNamingConvention())
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
             .Build();
 

--- a/build/ReleaseDiffGenerator/ReleaseDiffGenerator.csproj
+++ b/build/ReleaseDiffGenerator/ReleaseDiffGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/TocCombiner/Program.cs
+++ b/build/TocCombiner/Program.cs
@@ -24,5 +24,21 @@ namespace TocCombiner
             combined.AddRange(items.OrderBy(item => item.Name));
             YamlUtility.Serialize(Console.Out, combined, "YamlMime:TableOfContent");
         }
+
+        /* Later version of docfx...
+        static void Main(string[] args)
+        {
+            var items = new List<TocItemViewModel>();
+            TocRootViewModel combined = null;
+            foreach (var file in args)
+            {
+                Console.WriteLine("Loading " + file);
+                var toc = YamlUtility.Deserialize<TocRootViewModel>(file);
+                items.AddRange(toc.Items);
+                combined ??= toc;
+            }
+            combined.Items = new TocViewModel(items.OrderBy(item => item.Name));
+            YamlUtility.Serialize(Console.Out, combined, "YamlMime:TableOfContent");
+        }*/
     }
 }

--- a/build/TocCombiner/TocCombiner.csproj
+++ b/build/TocCombiner/TocCombiner.csproj
@@ -2,16 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DocAsCode.DataContracts.Common" Version="2.41.0" />
-    
-    <!-- Make sure we can build on non-Windows, even though we can't run. -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
-                  Version="1.0.0-preview.1"
-                  PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DocAsCode.DataContracts.Common" Version="2.66.2" />
   </ItemGroup>
 
 </Project>

--- a/build/Tools.sln
+++ b/build/Tools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28527.54
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocfxYamlLoader", "DocfxYamlLoader\DocfxYamlLoader.csproj", "{093336D7-DC55-421F-B6BE-9B22E9A47FF5}"
 EndProject
@@ -9,13 +9,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReleaseDiffGenerator", "Rel
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DocfxAnnotationGenerator", "DocfxAnnotationGenerator\DocfxAnnotationGenerator.csproj", "{201C875B-DB02-41FC-A7D2-C0C93E14EB3B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox", "Sandbox\Sandbox.csproj", "{597C6873-2141-42C0-BBFE-8F5CB1947C97}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnippetExtractor", "SnippetExtractor\SnippetExtractor.csproj", "{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SandcastleXrefGenerator", "SandcastleXrefGenerator\SandcastleXrefGenerator.csproj", "{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TocCombiner", "TocCombiner\TocCombiner.csproj", "{24055A70-E414-40E2-860A-D34E26711A8C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{0B9D3E02-0601-43EE-AC68-BD8ED86FE843}"
+	ProjectSection(SolutionItems) = preProject
+		buildapidocs.sh = buildapidocs.sh
+		buildweb.sh = buildweb.sh
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,16 +58,6 @@ Global
 		{201C875B-DB02-41FC-A7D2-C0C93E14EB3B}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
 		{201C875B-DB02-41FC-A7D2-C0C93E14EB3B}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{201C875B-DB02-41FC-A7D2-C0C93E14EB3B}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release|Any CPU.Build.0 = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
-		{597C6873-2141-42C0-BBFE-8F5CB1947C97}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
@@ -76,16 +68,6 @@ Global
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
 		{BDE8AD07-151B-4CBD-B146-2E8D1A6A092E}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Debug-AOT|Any CPU.Build.0 = Debug|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Signed|Any CPU.ActiveCfg = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Signed|Any CPU.Build.0 = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Unsigned|Any CPU.ActiveCfg = Release|Any CPU
-		{3AFC4036-376C-4D7A-8E23-0610C60CF6B5}.Release-Unsigned|Any CPU.Build.0 = Release|Any CPU
 		{24055A70-E414-40E2-860A-D34E26711A8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{24055A70-E414-40E2-860A-D34E26711A8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{24055A70-E414-40E2-860A-D34E26711A8C}.Debug-AOT|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
We can't upgrade to the latest version yet, as the TOC format has changed. We'll need to rewrite *old* TOCs to be in the new format first, as well as changing how we handle them. Sigh.

(This has led me to bump everything to .NET 6 though, which is a good thing regardless.)