### PR TITLE
Revert to docfx 2.62.2 for now

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.63.0",
+      "version": "2.62.2",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
2.63.0 builds, but the changed templates need js/css that we don't currently serve.

This will take longer to fix (and we might as well do it at the same time as going up to 2.66.2).