### PR TITLE
Fix generation of local NodaTime.Testing metadata

### DIFF
--- a/build/testing-docfx.json
+++ b/build/testing-docfx.json
@@ -1,0 +1,18 @@
+{ "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "NodaTime/NodaTime.csproj",
+            "NodaTime.Testing/NodaTime.Testing.csproj"
+          ],
+          "cwd": "../../nodatime/src"
+        }
+      ],
+      "dest": "tmp/metadata/NodaTime.Testing/unstable/fullapi",
+      "shouldSkipMarkup": true,
+      "properties": {
+        "TargetFramework": "netstandard2.0"
+      }
+    }
+]}


### PR DESCRIPTION
Without these changes, using saucecontrol.InheritDoc causes issues - but they were already inherent in this build.

Fundamentally there's a weakness in docfx here (yet again) but this should work round it.