### PR TITLE
Publish debug version of demo before extracting snippets

### DIFF
--- a/build/buildapidocs.sh
+++ b/build/buildapidocs.sh
@@ -85,7 +85,7 @@ dotnet run --project ReleaseDiffGenerator -- tmp/metadata/NodaTime
 dotnet run --project DocfxAnnotationGenerator -- tmp/metadata/*
 
 # Extract snippets from NodaTime.Demo (unstable only, for now)
-dotnet publish -v quiet ../../nodatime/src/NodaTime.Demo
+dotnet publish -c Debug -v quiet ../../nodatime/src/NodaTime.Demo
 dotnet run --project SnippetExtractor -- ../../nodatime/src/NodaTime.sln NodaTime.Demo tmp/metadata/NodaTime/unstable/overwrite
 
 # Reorganize the files to suit docfx build


### PR DESCRIPTION
(dotnet publish changed behaviour in .NET 8 to default to "Release", but we're looking for NodaTime.dll in "Debug")