### PR TITLE
Enable explicit interface implementation docs for testing

### DIFF
--- a/build/DocfxAnnotationGenerator/Program.cs
+++ b/build/DocfxAnnotationGenerator/Program.cs
@@ -71,13 +71,6 @@ namespace DocfxAnnotationGenerator
                 .SelectMany(rd => rd.Members)
                 .Select(member => member.DocfxUid)
                 .Where(uid => !unstableRelease.MembersByUid.ContainsKey(uid))
-                // Explicit interface implementation seems to cause problems for some reason.
-                // Not sure why, but let's ignore it for now... it really doesn't matter that
-                // it won't have any documentation.
-                .Where(uid => !uid.Contains(".System#Xml#Serialization#IXmlSerializable#") &&
-                              !uid.Contains(".System#IComparable#CompareTo") &&
-                              !uid.Contains(".NodaTime#TimeZones#IDateTimeZoneSource#ForId") &&
-                              !uid.Contains("#GetEnumerator"))
                 .Distinct()
                 .ToList();
             if (missing.Count != 0)

--- a/build/ReleaseDiffGenerator/Program.cs
+++ b/build/ReleaseDiffGenerator/Program.cs
@@ -41,10 +41,8 @@ namespace ReleaseDiffGenerator
 
         static void GenerateDiffs(Release oldRelease, Release newRelease, string destination)
         {
-            // IXmlSerializable.GetSchema seems to cause problems for some reason, so we exclude it.
-            var oldMemberUids = new HashSet<string>(oldRelease.MembersByUid.Keys.Where(IsNotGetSchema));
-            var newMemberUids = new HashSet<string>(newRelease.MembersByUid.Keys.Where(IsNotGetSchema));
-            bool IsNotGetSchema(string uid) => !uid.EndsWith(".System#Xml#Serialization#IXmlSerializable#GetSchema");
+            var oldMemberUids = new HashSet<string>(oldRelease.MembersByUid.Keys);
+            var newMemberUids = new HashSet<string>(newRelease.MembersByUid.Keys);
 
             var addedMembers = newMemberUids
                 .Except(oldMemberUids)

--- a/build/testing-docfx.json
+++ b/build/testing-docfx.json
@@ -11,6 +11,7 @@
       ],
       "dest": "tmp/metadata/NodaTime.Testing/unstable/fullapi",
       "shouldSkipMarkup": true,
+      "includeExplicitInterfaceImplementations": true,
       "properties": {
         "TargetFramework": "netstandard2.0"
       }


### PR DESCRIPTION
This means we can now get rid of all the special-casing that was in the tooling.