### PR TITLE
More testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Build pull request or PR
+
+on: 
+  pull_request:  
+  push:
+    branches:
+      - main
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          8.0.x
+
+    - name: Build and test
+      run: |
+        dotnet build build/Tools.sln
+        dotnet build -c Release src/NodaTime-Web.sln
+        dotnet test -c Release src/NodaTime.Web.Test

--- a/build/buildweb.sh
+++ b/build/buildweb.sh
@@ -30,8 +30,8 @@ dotnet publish -v quiet -c Release $ROOT/src/NodaTime.Web
 # (Blazor is currently disabled.)
 # sed -i 's/\\/\//g' $WEB_DIR/NodaTime.Web.Blazor.blazor.config
 
-# Run a smoke test to check it still works
-# dotnet test ../src/NodaTime.Web.SmokeTest
+# Run a smoke test to check it still works, but without using GCS
+STORAGE__BUCKET=local:fakestorage dotnet test ../src/NodaTime.Web.SmokeTest
 
 # Add diagnostic text files
 # commit.txt only contains commit info

--- a/src/NodaTime.Web.SmokeTest/FetchPagesTest.cs
+++ b/src/NodaTime.Web.SmokeTest/FetchPagesTest.cs
@@ -23,7 +23,7 @@ namespace NodaTime.Web.SmokeTest
         [TestCase("1.0.x/userguide/text", "There are two options for text handling")]
         [TestCase("1.0.x/api/NodaTime.DateTimeZone.html", "The mapping is unambiguous")]
         // Note: not the full URL as that depends on the server URL
-        [TestCase("tzdb/index.txt", "/tzdb/tzdb2013h.nzd")]
+        [TestCase("tzdb/index.txt", "/tzdb/tzdb2018h.nzd")]
         public async Task TextPage(string path, string expectedContent)
         {
             var client = new HttpClient();
@@ -32,7 +32,7 @@ namespace NodaTime.Web.SmokeTest
         }
 
         [Test]
-        [TestCase("tzdb/tzdb2013h.nzd", 125962)]
+        [TestCase("tzdb/tzdb2018h.nzd", 135698)]
         public async Task Binary(string path, int expectedSize)
         {
             var client = new HttpClient();

--- a/src/NodaTime.Web/appsettings.SmokeTests.json
+++ b/src/NodaTime.Web/appsettings.SmokeTests.json
@@ -6,6 +6,7 @@
   },
 
   "Storage": {
-    "BenchmarkLimit": 10
+    "BenchmarkLimit": 10,
+    //"Bucket": "local:fakestorage"
   }
 }


### PR DESCRIPTION
- Run smoke tests in buildweb.sh, but using the fake data
- Run unit tests on PR/push

When all this is in place, we can ditch AppVeyor.