### PR TITLE
Revert "Put the config in the right place..."

### DIFF
--- a/src/NodaTime.Web/appsettings.Production.json
+++ b/src/NodaTime.Web/appsettings.Production.json
@@ -5,12 +5,12 @@
       "LogLevel": {
         "Default": "None"
       }
+    },
+    "Network": {
+      "HttpsPort": 443,
+      "UseForwardedHeaders": true,
+      "ForwardLimit": 2,
+      "ForwardedHeaders": [ "XForwardedFor", "XForwardedProto" ]
     }
-  },
-  "Network": {
-    "HttpsPort": 443,
-    "UseForwardedHeaders": true,
-    "ForwardLimit": 2,
-    "ForwardedHeaders": [ "XForwardedFor", "XForwardedProto" ]
   }
 }

--- a/src/NodaTime.Web/appsettings.Staging.json
+++ b/src/NodaTime.Web/appsettings.Staging.json
@@ -11,12 +11,13 @@
       "LogLevel": {
         "Default": "None"
       }
+    },
+
+    "Network": {
+      "HttpsPort": 443,
+      "UseForwardedHeaders": true,
+      "ForwardLimit": 2,
+      "ForwardedHeaders": [ "XForwardedFor", "XForwardedProto" ]
     }
-  },
-  "Network": {
-    "HttpsPort": 443,
-    "UseForwardedHeaders": true,
-    "ForwardLimit": 2,
-    "ForwardedHeaders": [ "XForwardedFor", "XForwardedProto" ]
   }
 }


### PR DESCRIPTION
This reverts commit 0c5e7fdfdd5fadf6bb24e527f10b37b3043b2511.

This *did* put the config in the right place, but it was somewhat cataclysmic to do so, leading to every request getting a 301.

I'll experiment separately with how to do this properly (with a build that doesn't take 10 minutes...)