### PR TITLE
Specify smoke test URL directly in buildweb.sh

### DIFF
--- a/build/buildweb.sh
+++ b/build/buildweb.sh
@@ -34,7 +34,7 @@ dotnet publish -nologo -clp:NoSummary -v quiet -c Release $ROOT/src/NodaTime.Web
 # Skip this if we don't have API docs.
 if [[ "$1" != "--skip-api" ]]
 then
-  STORAGE__BUCKET=local:fakestorage dotnet test ../src/NodaTime.Web.SmokeTest
+  STORAGE__BUCKET=local:fakestorage ASPNETCORE_URLS=http://127.0.0.1:8080 dotnet test ../src/NodaTime.Web.SmokeTest
 fi
 
 # Add diagnostic text files


### PR DESCRIPTION
Without this, it looks like the server starts okay, but we can't fetch pages in the tests.