### PR TITLE
Temporarily disable benchmarks

### DIFF
--- a/src/NodaTime.Web/Services/BenchmarkRepository.cs
+++ b/src/NodaTime.Web/Services/BenchmarkRepository.cs
@@ -97,6 +97,12 @@ public class BenchmarkRepository : IRefreshableCache
             var limit = repository.limit;
             CacheEntry previous = this;
 
+            // We can just keep returning the current entry if we're asked not to do anything.
+            if (limit == 0 && Environments.Count == 0 && RunsById.Count == 0)
+            {
+                return this;
+            }
+
             // If we don't have previous work to finish off, check for new benchmarks.
             if (pendingContainersToBeDownloaded is null)
             {

--- a/src/NodaTime.Web/Views/Benchmarks/Index.cshtml
+++ b/src/NodaTime.Web/Views/Benchmarks/Index.cshtml
@@ -15,10 +15,8 @@
         <h1>Benchmarks</h1>
 
         <p>
-            Benchmarks are run on a daily basis (when there's been a change in the main branch)
-            on identical machines: one Linux (gabriel) and one Windows (bagpuss). The web interface
-            to view the benchmarks is still in a prototype phase; in particular, the URLs may well
-            change over time, so please don't rely on them being stable just yet.
+            Benchmarks are currently disabled (in terms of viewing), in an attempt to curb
+            web site traffic from scrapers. They may be re-enabled at a later date.
         </p>
 
         <h2>Benchmark environments</h2>

--- a/src/NodaTime.Web/appsettings.Production.json
+++ b/src/NodaTime.Web/appsettings.Production.json
@@ -1,2 +1,6 @@
 ﻿{
+  "Storage": {
+    // Temporarily disable benchmarks.
+    "BenchmarkLimit": 0
+  }
 }


### PR DESCRIPTION
We're getting a *lot* of traffic for benchmarks, despite robots.txt prohibiting traffic. It's not really of much use to anyone, so let's get rid of it.